### PR TITLE
Handle partial time values (#4)

### DIFF
--- a/index.tmpl
+++ b/index.tmpl
@@ -679,6 +679,15 @@
 
       }());
 
+      // check time format
+      document.getElementById('time').addEventListener('change', function() {
+        // append :00 minutes to 2-digit entry
+        var timeInput = document.getElementById('time');
+        if (/^\d\d$/.test(timeInput.value)) {
+          timeInput.value += ':00';
+        }
+      });
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
Comments? These commits add the following:
1. html5 validation using `pattern` attribute on date and time fields. This enforces the required format but doesn't necessarily come with intuitive warnings for the user
2. an `onchange` event handler that detects abbreviated time formats like '15' and changes them to '15:00'

Does the second case go far enough? Should '7' become '07:00'? Should '730' become '07:30'?
Should we be doing anything similar for dates?

ps: Should firefox implement date and time controls? Yes it should :)
